### PR TITLE
invoice_line casting to dbt_utils

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'quickbooks_source'
-version: '0.1.0'
+version: '0.1.1'
 
 require-dbt-version: [">=0.18.0", "<0.20.0"]
 

--- a/models/stg_quickbooks__invoice_line.sql
+++ b/models/stg_quickbooks__invoice_line.sql
@@ -44,9 +44,9 @@ final as (
         description,
         quantity,
         bundle_quantity,
-        cast(bundle_id as {{ 'int64' if target.name == 'bigquery' else 'bigint' }}) as bundle_id,
-        cast(account_id as {{ 'int64' if target.name == 'bigquery' else 'bigint' }} ) as account_id,
-        cast(item_id as {{ 'int64' if target.name == 'bigquery' else 'bigint' }}) as item_id
+        cast(bundle_id as {{ dbt_utils.type_int() }}) as bundle_id,
+        cast(account_id as {{ dbt_utils.type_int() }}) as account_id,
+        cast(item_id as {{ dbt_utils.type_int() }}) as item_id
     from fields
 )
 


### PR DESCRIPTION
The minor changes in this branch consist of:

- Fixing missed macro casting for three fields within the `stg_quickbooks__invoice_line` model from the custom macro -> dbt_utils.
       -  Error was being thrown by the customer where the target.name was not bigquery. The dbt_utils macro will fix this issue.
- Update of the project version from v0.1.0 -> v0.1.1.