### PR TITLE
postgres compatibility updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,19 @@ jobs:
             dbt deps
             dbt seed --target redshift --full-refresh
             dbt run --target redshift --full-refresh
+            dbt run  --vars '{using_address: false,using_bill: false, using_credit_memo: false, using_department: false, using_deposit: false, using_estimate: false, using_invoice: false, using_invoice_bundle: false, using_journal_entry: false, using_payment: false, using_refund_receipt: false, using_transfer: false, using_vendor_credit: false, using_sales_receipt: false}' --target redshift --full-refresh
             dbt test --target redshift
+      - run:
+          name: "Run Tests - Postgres"
+          command: |
+            . venv/bin/activate
+            echo `pwd`
+            cd integration_tests
+            dbt deps
+            dbt seed --target postgres --full-refresh
+            dbt run --target postgres --full-refresh
+            dbt run  --vars '{using_address: false,using_bill: false, using_credit_memo: false, using_department: false, using_deposit: false, using_estimate: false, using_invoice: false, using_invoice_bundle: false, using_journal_entry: false, using_payment: false, using_refund_receipt: false, using_transfer: false, using_vendor_credit: false, using_sales_receipt: false}' --target postgres --full-refresh
+            dbt test --target postgres
       - run:
           name: "Run Tests - Snowflake"
           command: |
@@ -40,6 +52,7 @@ jobs:
             dbt deps
             dbt seed --target snowflake --full-refresh
             dbt run --target snowflake --full-refresh
+            dbt run  --vars '{using_address: false,using_bill: false, using_credit_memo: false, using_department: false, using_deposit: false, using_estimate: false, using_invoice: false, using_invoice_bundle: false, using_journal_entry: false, using_payment: false, using_refund_receipt: false, using_transfer: false, using_vendor_credit: false, using_sales_receipt: false}' --target snowflake --full-refresh
             dbt test --target snowflake
       - run:
           name: "Run Tests - BigQuery"
@@ -51,8 +64,9 @@ jobs:
             echo `pwd`
             cd integration_tests
             dbt deps
-            dbt seed --target bigquery
+            dbt seed --target bigquery --full-refresh
             dbt run --target bigquery --full-refresh
+            dbt run  --vars '{using_address: false,using_bill: false, using_credit_memo: false, using_department: false, using_deposit: false, using_estimate: false, using_invoice: false, using_invoice_bundle: false, using_journal_entry: false, using_payment: false, using_refund_receipt: false, using_transfer: false, using_vendor_credit: false, using_sales_receipt: false}' --target bigquery --full-refresh
             dbt test --target bigquery
       - save_cache:
           key: deps2-{{ .Branch }}

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This package takes into consideration that not every QuickBooks account utilizes
 ...
 vars:
   quickbooks_source:
+    using_address:        false         #disable if you don't have addresses in QuickBooks
     using_bill:           false         #disable if you don't have bills or bill payments in QuickBooks
     using_credit_memo:    false         #disable if you don't have credit memos in QuickBooks
     using_department:     false         #disable if you don't have departments in QuickBooks

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'quickbooks_source'
-version: '0.2.0'
+version: '0.2.1'
 
 require-dbt-version: [">=0.18.0", "<0.20.0"]
 
@@ -55,6 +55,7 @@ vars:
     vendor:                     "{{ source('quickbooks','vendor') }}"
 
     #Variables if your company utilizes the below parent and child transactional tables.
+    using_address:        True
     using_bill:           True
     using_credit_memo:    True
     using_department:     True

--- a/integration_tests/ci/sample.profiles.yml
+++ b/integration_tests/ci/sample.profiles.yml
@@ -18,6 +18,15 @@ integration_tests:
       port: 5439
       schema: quickbooks_source_integration_tests
       threads: 8
+    postgres:
+      type: postgres
+      host: "{{ env_var('CI_POSTGRES_DBT_HOST') }}"
+      user: "{{ env_var('CI_POSTGRES_DBT_USER') }}"
+      pass: "{{ env_var('CI_POSTGRES_DBT_PASS') }}"
+      dbname: "{{ env_var('CI_POSTGRES_DBT_DBNAME') }}"
+      port: 5432
+      schema: quickbooks_source_integration_tests
+      threads: 8
     bigquery:
       type: bigquery
       method: service-account

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'quickbooks_source_integration_tests'
-version: '0.2.0'
+version: '0.2.1'
 profile: 'integration_tests'
 config-version: 2
 
@@ -55,46 +55,6 @@ vars:
 seeds:
     +quote_columns: "{{ true if target.type == 'redshift' else false }}"
     quickbooks_source_integration_tests:
-      account_data:
-      address_data:
-      bill_line_data:
-      bill_linked_txn_data:
-      bill_payment_line_data:
-      bill_payment_data:
-      bill_data:
-      bundle_item_data:
-      bundle_data:
-      credit_memo_data:
-      credit_memo_line_data:
-      customer_data:
-      department_data:
-      department_data:
-      deposit_line_data:
-      deposit_data:
-      estimate_data:
-      estimate_line_data:
-      incoice_data:
-      invoice_line_data:
-      invoice_line_bundle_data:
-      invoice_linked_txn_data:
-      item_data:
-      journal_entry_line_data:
-      journal_entry_data:
-      payment_data:
-      payment_line_data:
-      purchase_line_data:
-      purchase_data:
-      purchase_order_data:
-      purchase_order_line_data:
-      purchase_order_linked_txn_data:
-      refund_receipt_line_data:
-      refund_receipt_data:
-      sales_receipt_line_data:
-      sales_receipt_data:
-      transfer_data:      
-      vendor_credit_line_data:
-      vendor_credit_data:
-      vendor_data:
 
 clean-targets:
     - target

--- a/models/stg_quickbooks__address.sql
+++ b/models/stg_quickbooks__address.sql
@@ -1,3 +1,6 @@
+--To disable this model, set the using_address variable within your dbt_project.yml file to False.
+{{ config(enabled=var('using_address', True)) }}
+
 with base as (
 
     select * 

--- a/models/tmp/stg_quickbooks__address_tmp.sql
+++ b/models/tmp/stg_quickbooks__address_tmp.sql
@@ -1,2 +1,5 @@
+--To disable this model, set the using_address variable within your dbt_project.yml file to False.
+{{ config(enabled=var('using_address', True)) }}
+
 select * 
 from {{ var('address') }}


### PR DESCRIPTION
This PR includes the following updates:

- Addresses dbt_quickbooks Issue [#10](https://github.com/fivetran/dbt_quickbooks/issues/10) by incorporating Postgres compatibility and adding Postgres testing to CircleCi. 
- Addresses dbt_quickbooks Issue [#11](https://github.com/fivetran/dbt_quickbooks/issues/11) by adding a variable to disable the use of the address table.
- Upgrades the to v0.2.1